### PR TITLE
Update GNMLink.txt

### DIFF
--- a/Spicy 3.02/Stroke/Link/GNMLink.txt
+++ b/Spicy 3.02/Stroke/Link/GNMLink.txt
@@ -1,4 +1,3 @@
-@NullResponse @StopStroking 
 @NullResponse @RapidCodeOn
 @NullResponse @DeleteFlag(Busy)
 @NullResponse @DeleteFlag(NoStrokeEdge)
@@ -20,7 +19,7 @@
 (Continue1)
 @Variable[GNMMerits]<[DommeContentVAnnoyed] @NullResponse @ChangeVar[GNMMerits]=[GNMMerits]+[#Random(20,50)]
 @Variable[GNMMerits]>[DommeContentVPleased] @NullResponse @ChangeVar[GNMMerits]=[GNMMerits]-[#Random(20,50)]
-@NullResponse @Chance100(Links) @Goto(Other)
+@NullResponse @Chance33(Links) @Goto(Other)
 (Links)
 @NullResponse @CallReturn(CR\Links\*.txt)
 (Other)
@@ -58,23 +57,21 @@
 @NullResponse @TempFlag(NoStrokeEdge)
 @Variable[10]>[#Random(1,100)] You only stroke the shaft #DT
 @Variable[10]>[#Random(1,100)] You may only stroke with your non-dominant hand #DT
-#GNMStartStroking @ShowImage
+#GNMStartStroking @StartStroking @ShowImage
 @End
 (MaybeEdge)
 @NullResponse @TempFlag(MaybeStrokeEdge)
 @Variable[10]>[#Random(1,100)] You only stroke the shaft #DT
 @Variable[10]>[#Random(1,100)] You may only stroke with your non-dominant hand #DT
-#GNMStartStroking @ShowImage
+#GNMStartStroking @StartStroking @ShowImage
 @End
 (Edge)
 @NullResponse @TempFlag(YesStrokeEdge)
 @Variable[10]>[#Random(1,100)] You only stroke the shaft #DT
 @Variable[10]>[#Random(1,100)] You may only stroke with your non-dominant hand #DT
-#GNMStartStroking @ShowImage
+#GNMStartStroking @StartStroking @ShowImage
 @End
-(Locked)
-@RT(Time to tease your locked up #GNMCock,Lets make it twitch #GNMGrin,I have a fun chastity exercise!,You're absolutely gonna hate this!) #DT @StartTaunts
-@End
+
 (End)
 @NullResponse @Interrupt(GNMEnd)
 


### PR DESCRIPTION
Important for StrokStart And without @StartStroking the program does not automatical stop the Stroking. also important for the use of the Tease AI Metronome. You have to disable the Spicy-/ or the TeaseAI-metronome. but this is the only way to run it correctly. I also change the #GNMStartStroking 

line 22 @NullResponse @Chance33(Links) @Goto(Other) 
you can only input a value between 00 and 99
do you want to add it to Stroke\Link\GNMLink_CHASTITY.txt ? maybe with a higher chance? or is there a stroking part?